### PR TITLE
Multiple directories upload

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,20 +19,41 @@ const makeAppDir = (req, res, next) => {
     dictionaries: [adjectives, animals]
   });
 
-  makeDir(`./uploads/${appFolderName}`)
+  const dir = `./uploads/${appFolderName}`
+
+  if (!fs.existsSync(dir)){          // create folder if not exists TODO: might need to handle "if exists"
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  
   req.appDir = appFolderName;
   next()
 };
+
+const getFile = (originalFilename) => {
+  return originalFilename.split("|").pop();
+}
+
+const getFolderPath = (appFolder, originalFilename) => {
+  const topDir = `./uploads/${appFolder}/`;
+  const filePath = originalFilename.substring(0, originalFilename.lastIndexOf("|")).split("|").join("/");
+  const folderPath = `${topDir}${filePath}`;
+
+  if (!fs.existsSync(folderPath)){
+    fs.mkdirSync(folderPath, { recursive: true });
+  }
+
+  return folderPath;
+}
 
 /**
  * Multer create file storage engine and store
  */
 const fileStorageEngine = multer.diskStorage({
   destination: (req, file, cb) => {
-    cb(null, `./uploads/${req.appDir}`);
+    cb(null, `${getFolderPath(req.appDir, file.originalname)}`);
   },
   filename: (req, file, cb) => {
-    cb(null, file.originalname);
+    cb(null, getFile(file.originalname));
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const multer = require('multer');
 const fs = require('fs');
-const makeDir = require('make-dir');
 const { uniqueNamesGenerator, adjectives, animals } = require('unique-names-generator');
 const cors = require('cors');
 const dockerCLI = require('docker-cli-js');
@@ -112,7 +111,7 @@ const buildImage = (res, dir, image) => {
 app.post("/upload", makeAppDir, upload.array("files"), (req, res) => {
   const { imageName } = req.body;
   const { appDir } = req;
-  
+
   buildImage(res, appDir, imageName);
 });
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "cors": "^2.8.5",
     "docker-cli-js": "^2.8.0",
     "express": "^4.17.1",
-    "make-dir": "^3.1.0",
     "multer": "^1.4.2",
     "unique-names-generator": "^4.6.0"
   }


### PR DESCRIPTION
- This PR handles the upload of multiple directories.
- Uses a frontend drag and drop folder to test.
- Also removes the `make-dir` node package and instead uses native `fs` for file operations.